### PR TITLE
Fix: 88919cbe4f9f836b407cc02bb2299a8821bf427e

### DIFF
--- a/src/main/java/urlshortener/web/UrlShortenerController.java
+++ b/src/main/java/urlshortener/web/UrlShortenerController.java
@@ -55,7 +55,7 @@ public class UrlShortenerController {
         boolean ret = false;
         try {
             ret = InetAddress.getByName(new URL(url_s).getHost()).isReachable(1000);
-            if (!ret) {
+            if (ret) {
                 int responseCode = 400;
                 URL url = new URL(url_s);
                 HttpURLConnection huc = (HttpURLConnection) url.openConnection();

--- a/src/test/java/urlshortener/web/UrlShortenerTests3.java
+++ b/src/test/java/urlshortener/web/UrlShortenerTests3.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppC
 import java.net.URI;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.stubbing.Answer;
@@ -75,6 +76,22 @@ public class UrlShortenerTests3 {
                                      .param("sponsor", "sponsor"))
         .andDo(print())
         .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @Ignore
+    public void AddExistingURIAfter301ToHttps() throws Exception {
+
+        when(shortUrlService.findByKey("sponsor")).thenReturn(someUrl());
+
+        mockMvc.perform(post("/link").param("url", "http://animeflv.net/"))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(redirectedUrl("http://localhost/6972dee0"))
+        .andExpect(jsonPath("$.hash", is("6972dee0")))
+        .andExpect(jsonPath("$.uri", is("http://localhost/6972dee0")))
+        .andExpect(jsonPath("$.target", is("https://animeflv.net/")))
+        .andExpect(jsonPath("$.sponsor", is(nullValue())));
     }
 
     @Test


### PR DESCRIPTION
**Evento:** @JaviBite amonestado.
**Motivo:** Subir a Git una versión que rompía la integración continua.

El método `InetAddress.isReachable()` (see [reference](https://docs.oracle.com/javase/7/docs/api/java/net/InetAddress.html#isReachable(int))) sólo comprueba que sea alcanzable a nivel de capa de transporte (TCP), pero no comprueba que la capa de aplicación (HTTP) devuelve OK (200).

> Test whether that address is reachable. Best effort is made by the implementation to try to reach the host, but firewalls and server configuration may block requests resulting in a unreachable status while some specific ports may be accessible. A typical implementation will use ICMP ECHO REQUESTs if the privilege can be obtained, otherwise it will try to establish a TCP connection on port 7 (Echo) of the destination host.

Debido a esto las comprobaciones de `InetAddress` y `HttpURLConnection` son **complementarias** y ambas deben ser superadas (no sólo una).

Se ha implementado un test (por ahora con anotación `@Ignore`) que comprueba que la dirección [http://animeflv.net](http://animeflv.net) es accesible. Téngase en cuenta que accediendo con protocolo `HTTP` este dominio redirige a su homónimo `HTTPS`.

```
Request URL: http://animeflv.net/
Request Method: GET
Status Code: 301 Moved Permanently
...
Location: https://animeflv.net/
```

Para comprobar que la URI es accesible se deben seguir la redirecciones `30X` hasta encontrar la localización correcta, y **almacenar dicha localización**. Para ello hay dos alternativas:

1. Buscar una biblioteca que ejecute las redirecciones automáticamente (aunque supongan un cambio del protocolo).

1. Seguir las redirecciones manualmente (see [example](https://www.mkyong.com/java/java-httpurlconnection-follow-redirect-example/)).